### PR TITLE
[변경] 챔피언의 공격과 피격 구조를 미니언, 포탑 등과 같게 재구조

### DIFF
--- a/Assets/Resources/Prefabs/FootmanHP.prefab
+++ b/Assets/Resources/Prefabs/FootmanHP.prefab
@@ -941,6 +941,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _lockTarget: {fileID: 0}
+  _currentAttacker: {fileID: 0}
   HPSlider: {fileID: 6048292626844819750}
   _state: 0
 --- !u!54 &-323424216349625699

--- a/Assets/Scripts/Character/ChampionManager.cs
+++ b/Assets/Scripts/Character/ChampionManager.cs
@@ -1,30 +1,18 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using Photon.Pun;
+using Photon.Realtime;
 
-public class ChampionManager : MonoBehaviour
+public class ChampionManager : Controller
 {
-    /*
-    public int level;
-    public int exp;
-    public float maxHealth;
-    public float healthRegen;
-    public float health;
-    public float armor;
-    public float attackDmg;
-    public float abilityPower;
-    public float mana;
-    public float manaRegen;
-    public float speed;
-    public float attackSpeed;
-    public float attackTime;
-    */
-
     public int skillPoint;
 
     HeroCombat heroCombatScript;
     PlayerAnimation playerAnim;
     ChampionStat stat;
+
+    [SerializeField] GameObject currentAttacker;
 
     void Start()
     {
@@ -70,6 +58,36 @@ public class ChampionManager : MonoBehaviour
             stat.Status.exp = 0;
             stat.Status.level++;
             skillPoint++;
+        }
+    }
+
+    public override void TakeDamage(float damage, GameObject attacker = null)
+    {
+        if (attacker != null)
+        {
+            currentAttacker = attacker;
+        }
+
+        stat.Status.hp -= stat.Status.atk * (100 / (100 + heroCombatScript.targetedEnemy.GetComponent<ObjectStat>().Status.defense));
+
+        if (stat.Status.hp <= 0)
+        {
+            Invoke("OnDie", 30f);
+            return;
+        }
+    }
+
+    public void OnDie()
+    {
+        if(Util.GetLocalPlayerId() <= 5)
+        {
+            // 블루팀 리스폰
+            transform.Translate(new Vector3(-105, 0, -105));
+        }
+        else
+        {
+            // 레드팀 리스폰
+            transform.Translate(new Vector3(105, 0, 105));
         }
     }
 }

--- a/Assets/Scripts/Character/HeroCombat.cs
+++ b/Assets/Scripts/Character/HeroCombat.cs
@@ -83,6 +83,7 @@ public class HeroCombat : MonoBehaviour
 
     public void MeleeAttack()
     {
+        /*
         if(targetedEnemy != null)
         {
             if(targetedEnemy.GetComponent<Targetable>().enemyType == Targetable.EnemyType.Minion)
@@ -97,6 +98,8 @@ public class HeroCombat : MonoBehaviour
                 targetedEnemy.GetComponent<ChampionStat>().Status.hp -= stat.Status.atk * (100 / (100 + targetedEnemy.GetComponent<ChampionStat>().Status.defense));
             }
         }
+        */
+        targetedEnemy.GetComponent<Controller>().TakeDamage(stat.Status.atk, this.gameObject);
 
         performMeleeAttack = true;
     }

--- a/Assets/Scripts/Character/THSSkill_EProj.cs
+++ b/Assets/Scripts/Character/THSSkill_EProj.cs
@@ -20,4 +20,13 @@ public class THSSkill_EProj : MonoBehaviour
         yield return new WaitForSeconds(0.55f);
         Destroy(gameObject);
     }
+
+    void OnTriggerEnter(Collider other)
+    {
+        if(other.tag == "Enemy")
+        {
+            other.GetComponent<Controller>().TakeDamage(damage, this.gameObject);
+        }
+    }
+
 }

--- a/Assets/Scripts/Character/THSSkill_RProj.cs
+++ b/Assets/Scripts/Character/THSSkill_RProj.cs
@@ -20,5 +20,13 @@ public class THSSkill_RProj : MonoBehaviour
         yield return new WaitForSeconds(0.65f);
         Destroy(gameObject);
     }
+    void OnTriggerEnter(Collider other)
+    {
+        if (other.tag == "Enemy")
+        {
+            other.GetComponent<Controller>().TakeDamage(damage, this.gameObject);
+        }
+    }
+
 }
 


### PR DESCRIPTION
챔피언의 공격과 피격 구조를 미니언, 포탑 등과 같게 재구조
모든 오브젝트의 피격은 같은 구조(Controller의 TakeDamage)를 갖게 됨

관련 이슈 : #99